### PR TITLE
Stop marshalling Blockhash in json in UnforgeOperationInput

### DIFF
--- a/rpc/operations.go
+++ b/rpc/operations.go
@@ -73,7 +73,7 @@ Function:
 	func (c *Client) UnforgeOperationWithRPC(blockhash string, operation string, checkSignature bool) (Operations, error) {}
 */
 type UnforgeOperationInput struct {
-	Blockhash      string             `validate:"required"`
+	Blockhash      string             `json:"-" validate:"required"`
 	Operations     []UnforgeOperation `json:"operations" validate:"required"`
 	CheckSignature bool               `json:"check_signature"`
 }


### PR DESCRIPTION
The Blockhash field is absent in the rpc request, but go marshalls it by default when the `json:"-"` tag is missing. I figure adding it explicitly won't hurt anyone.